### PR TITLE
Fix multi hole skins winning

### DIFF
--- a/src/data/utils.js
+++ b/src/data/utils.js
@@ -8,8 +8,8 @@ import first from 'lodash/first';
 import last from 'lodash/last';
 import isEmpty from 'lodash/isEmpty';
 import map from 'lodash/map';
+import mapValues from 'lodash/mapValues';
 
-import { mapValues } from 'lodash';
 import { PLAYERS } from '../constants';
 
 export function getPlayerInfo(search) {
@@ -194,7 +194,7 @@ function getSkinWinner(scores) {
 /**
  * @param {Score[]} scores All round scores for a people playing skins
  * @param {string} player id of a player to see how many skins they won
- * @param {number} hole The hole in question
+ * @param {string} hole The hole in question
  * @returns {number} The number of skins won by this player on this hole
  */
 export function skinCountForHole(scores, player, hole) {
@@ -206,14 +206,16 @@ export function skinCountForHole(scores, player, hole) {
   // Great, this player won the current hole. Look back to see if there were
   // pushes leading up to this.
   let skinsWon = 1;
-  let holeInQuestion = hole - 1;
-  while (holeInQuestion > 0) {
+  let holeInQuestion = hole;
+  while (holeInQuestion !== '1') {
+    // H4x, a kinda safe-ish way to decrement the hole number (since it it
+    // stored as a string everywhere.
+    holeInQuestion = ''+(--holeInQuestion);
     const earlierHoleScores = filter(scores, { hole: holeInQuestion });
     if (getSkinWinner(earlierHoleScores) !== undefined) {
       break;
     }
     skinsWon += 1;
-    holeInQuestion -= 1;
   }
 
   return skinsWon;


### PR DESCRIPTION
I’d changed holes to be stored as strings everywhere (Since they always come out of dictionary keys like that). The downside is that it becomes harder to go to the next or previous hole. Future code shouldn’t need this if the API makes this function obsolete.